### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/856/321/61/85632161.geojson
+++ b/data/856/321/61/85632161.geojson
@@ -836,6 +836,9 @@
     ],
     "wof:country":"MO",
     "wof:country_alpha3":"MAC",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"f771682454c995c209503eff6ed71bb8",
     "wof:hierarchy":[
         {
@@ -853,7 +856,7 @@
         "zho",
         "por"
     ],
-    "wof:lastmodified":1566611805,
+    "wof:lastmodified":1582379116,
     "wof:name":"Macau S.A.R.",
     "wof:parent_id":102191569,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.