### PR TITLE
Name updates

### DIFF
--- a/data/856/321/61/85632161.geojson
+++ b/data/856/321/61/85632161.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002313,
-    "geom:area_square_m":26489652.931208,
+    "geom:area_square_m":26489574.042978,
     "geom:bbox":"113.528492,22.109444,113.591269,22.217153",
     "geom:latitude":22.158225,
     "geom:longitude":113.557709,
@@ -151,6 +151,9 @@
         "Makao",
         "Macau"
     ],
+    "name:diq_x_preferred":[
+        "Makao"
+    ],
     "name:div_x_preferred":[
         "\u0789\u07a6\u0786\u07a7\u0787\u07ab"
     ],
@@ -162,6 +165,12 @@
     ],
     "name:ell_x_variant":[
         "\u039c\u03b1\u03ba\u03ac\u03bf"
+    ],
+    "name:eng_ca_x_preferred":[
+        "Macau"
+    ],
+    "name:eng_gb_x_preferred":[
+        "Macau"
     ],
     "name:eng_x_preferred":[
         "Macau S.A.R."
@@ -213,6 +222,9 @@
     "name:fra_x_preferred":[
         "Macao"
     ],
+    "name:frr_x_preferred":[
+        "Macau"
+    ],
     "name:fry_x_preferred":[
         "Makao"
     ],
@@ -221,6 +233,9 @@
     ],
     "name:gan_x_preferred":[
         "\u6fb3\u9580"
+    ],
+    "name:gcr_x_preferred":[
+        "Makao"
     ],
     "name:gla_x_preferred":[
         "Macau"
@@ -425,6 +440,9 @@
     "name:mon_x_preferred":[
         "\u041c\u0430\u043a\u0430\u043e"
     ],
+    "name:mri_x_preferred":[
+        "Makao"
+    ],
     "name:msa_x_preferred":[
         "Macau"
     ],
@@ -468,6 +486,9 @@
     "name:nov_x_preferred":[
         "Makau"
     ],
+    "name:nya_x_preferred":[
+        "Macau"
+    ],
     "name:oci_x_preferred":[
         "Macau"
     ],
@@ -495,6 +516,9 @@
     "name:pol_x_preferred":[
         "Makau"
     ],
+    "name:por_br_x_preferred":[
+        "Macau"
+    ],
     "name:por_x_preferred":[
         "Macau"
     ],
@@ -515,6 +539,9 @@
     ],
     "name:rus_x_variant":[
         "\u0410\u043e\u043c\u044b\u043d\u044c"
+    ],
+    "name:sat_x_preferred":[
+        "\u1c62\u1c5f\u1c60\u1c5f\u1c63"
     ],
     "name:scn_x_preferred":[
         "Macau"
@@ -566,6 +593,9 @@
     ],
     "name:szl_x_preferred":[
         "Makau"
+    ],
+    "name:szy_x_preferred":[
+        "Macau"
     ],
     "name:tam_x_preferred":[
         "\u0bae\u0b95\u0bbe\u0bb5\u0bcb"
@@ -644,6 +674,9 @@
     ],
     "name:xmf_x_preferred":[
         "\u10db\u10d0\u10d9\u10d0\u10dd"
+    ],
+    "name:yid_x_preferred":[
+        "\u05de\u05d0\u05e7\u05d0\u05d0"
     ],
     "name:yor_x_preferred":[
         "M\u00e0k\u00e1\u00f9"
@@ -857,7 +890,7 @@
         "zho",
         "por"
     ],
-    "wof:lastmodified":1583797383,
+    "wof:lastmodified":1587428743,
     "wof:name":"Macau S.A.R.",
     "wof:parent_id":102191569,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1796 and https://github.com/whosonfirst-data/whosonfirst-data/issues/1821.

This PR includes:
- Fixes to property values that start or end with `" "`, `\n`, or `\r`, removing those characters.
- Using a modified version of the [wiki names import script](https://github.com/whosonfirst/whosonfirst-cookbook/blob/master/scripts/crawl_to_add_wiki_names.py), adds new `name` properties

There will be ~260 similar PRs, one for each per-country repo. No PIP work require, can merge as-is.