### PR TITLE
mo concordances, placetype local, and more

### DIFF
--- a/data/856/321/61/85632161.geojson
+++ b/data/856/321/61/85632161.geojson
@@ -1017,6 +1017,7 @@
         "hasc:id":"MO",
         "icao:code":"B-M",
         "ioc:id":"MAC",
+        "iso:code":"MO",
         "iso:id":"CN-MO",
         "itu:id":"MAC",
         "m49:code":"446",
@@ -1028,6 +1029,7 @@
         "wd:id":"Q14773",
         "wmo:id":"MU"
     },
+    "wof:concordances_official":"iso:code",
     "wof:controlled":[
         "wof:hierarchy",
         "wof:parent_id"
@@ -1058,7 +1060,7 @@
         "zho",
         "por"
     ],
-    "wof:lastmodified":1694639561,
+    "wof:lastmodified":1695881220,
     "wof:name":"Macau S.A.R.",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/812/91/85681291.geojson
+++ b/data/856/812/91/85681291.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002633,
-    "geom:area_square_m":30156426.589255,
+    "geom:area_square_m":30156577.897198,
     "geom:bbox":"113.519867,22.105373,113.587494,22.220771",
     "geom:latitude":22.157785,
     "geom:longitude":113.550197,
@@ -679,16 +679,18 @@
         "fips:code":"MC02",
         "gp:id":20070017,
         "hasc:id":"MO.MA",
+        "iso:code":"MO-M",
         "iso:id":"MO-M",
         "qs_pg:id":891785,
         "wd:id":"Q14773"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         85632161,
         102027981
     ],
     "wof:country":"MO",
-    "wof:geomhash":"c926e822cc1439a4cf08f9bd689c2460",
+    "wof:geomhash":"7890ae45495046db5e85cff8573f5a44",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -706,7 +708,7 @@
         "zho",
         "por"
     ],
-    "wof:lastmodified":1690939772,
+    "wof:lastmodified":1695884325,
     "wof:name":"Macau",
     "wof:parent_id":85632161,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.